### PR TITLE
Custom Word Template doesn't load - return Null

### DIFF
--- a/Private/Main/Get-DocumentPath.ps1
+++ b/Private/Main/Get-DocumentPath.ps1
@@ -10,7 +10,7 @@ function Get-DocumentPath {
         $WordDocument = Get-WordDocument -FilePath "$($MyInvocation.MyCommand.Module.ModuleBase)\Templates\WordTemplate.docx"
     } else {
         if ($Document.Configuration.Prettify.CustomTemplatePath) {
-            if (Test-File -File $Document.Configuration.Prettify.CustomTemplatePath -FileName 'CustomTemplatePath' -eq 0) {
+            if ($(Test-File -File $Document.Configuration.Prettify.CustomTemplatePath -FileName 'CustomTemplatePath') -eq 0) {
                 # Write-Verbose 'Get-DocumentPath - Option 2'
                 $WordDocument = Get-WordDocument -FilePath $Document.Configuration.Prettify.CustomTemplatePath
             } else {


### PR DESCRIPTION
If a custom template is choosen, the function Get-DocumentPath returns " Null"
After debugging I realized, that the reason is the if statement in line 13.
The function Test-File needs to be in separate brackets.
Otherwise the result of the if statement is just empty instead of $true or $false.