### PR TITLE
Fix PowerShell Gallery preview badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <a href="https://dev.azure.com/evotecpl/PSWinDocumentation/_build/latest?definitionId=3"><img src="https://dev.azure.com/evotecpl/PSWinDocumentation/_apis/build/status/EvotecIT.PSWinDocumentation"></a>
   <a href="https://www.powershellgallery.com/packages/PSWinDocumentation"><img src="https://img.shields.io/powershellgallery/v/PSWinDocumentation.svg"></a>
-  <a href="https://www.powershellgallery.com/packages/PSWinDocumentation"><img src="https://img.shields.io/powershellgallery/vpre/PSWinDocumentation.svg?label=powershell%20gallery%20preview&colorB=yellow"></a>
+  <a href="https://www.powershellgallery.com/packages/PSWinDocumentation"><img src="https://img.shields.io/powershellgallery/v/PSWinDocumentation.svg?label=powershell%20gallery%20preview&colorB=yellow&include_prereleases"></a>
   <a href="https://github.com/EvotecIT/PSWinDocumentation"><img src="https://img.shields.io/github/license/EvotecIT/PSWinDocumentation.svg"></a>
 </p>
 


### PR DESCRIPTION
Shields changed the PowerShell Gallery prerelease badge endpoint and the old vpre badge now renders a placeholder link.

This updates README badge URLs to use the normal PowerShell Gallery version badge with include_prereleases, so it displays the prerelease version again.

Ref: https://github.com/badges/shields/issues/11583